### PR TITLE
Added "follow" to get the HTML of the page being redirected to

### DIFF
--- a/director-genders.rb
+++ b/director-genders.rb
@@ -9,7 +9,7 @@ women = 0
 CSV.foreach('watched.csv', headers: true) do |movie|
   next if movie.header_row?
 
-  movie_doc = Nokogiri::HTML(HTTP.get(movie[3]).to_s)
+  movie_doc = Nokogiri::HTML(HTTP.follow.get(movie[3]).to_s)
 
   tmdb_id = movie_doc.at_xpath('/html/body/@data-tmdb-id')
 


### PR DESCRIPTION
Thank you for making this tool!

I gave it a go, but unfortunately I think the line: `movie_doc = Nokogiri::HTML(HTTP.get(movie[3]).to_s)` doesn't work as intended because the URL is a redirect (e.g. https://boxd.it/2auI), which therefore doesn't contain the TMDB ID.

I have zero knowledge of Ruby, but I discovered that putting `follow` in the command makes it get the HTML of the page being redirected to (e.g. https://letterboxd.com/film/12-angry-men/). After doing that change, the tool ran successfully and displayed the statistics. I've put that change in this pull request.